### PR TITLE
added required properties as expected for validation

### DIFF
--- a/neumai/neumai/SinkConnectors/SupabaseSink.py
+++ b/neumai/neumai/SinkConnectors/SupabaseSink.py
@@ -23,7 +23,7 @@ class SupabaseSink(SinkConnector):
     database_connection : str
         Connection string or details required to connect to the Supabase database.
 
-    collection_name : Optional[str]
+    collection_name : str
         Optional name of the collection within Supabase where the data will be stored.
     """
 
@@ -37,11 +37,11 @@ class SupabaseSink(SinkConnector):
     
     @property
     def required_properties(self) -> List[str]:
-        return ['database_connection']
+        return ['database_connection', 'collection_name']
 
     @property
     def optional_properties(self) -> List[str]:
-        return ['collection_name']
+        return []
 
     def validation(self) -> bool:
         """config_validation connector setup"""

--- a/neumai/neumai/SinkConnectors/WeaviateSink.py
+++ b/neumai/neumai/SinkConnectors/WeaviateSink.py
@@ -27,7 +27,7 @@ class WeaviateSink(SinkConnector):
     api_key : str
         The API key for authenticating with the Weaviate service. This key is necessary for secure communication with the Weaviate instance.
 
-    class_name : Optional[str]
+    class_name : str
         An optional class name within Weaviate to which the data will be associated. Specifies the schema or type of data being stored.
 
     num_workers : Optional[int]
@@ -68,11 +68,11 @@ class WeaviateSink(SinkConnector):
     
     @property
     def required_properties(self) -> List[str]:
-        return ['url', 'api_key']
+        return ['url', 'api_key', 'class_name']
 
     @property
     def optional_properties(self) -> List[str]:
-        return ['class_name', 'num_workers', 'shard_count', 'batch_size', 'is_dynamic_batch', 'batch_connection_error_retries']
+        return ['num_workers', 'shard_count', 'batch_size', 'is_dynamic_batch', 'batch_connection_error_retries']
 
     def validation(self) -> bool:
         """config_validation connector setup"""


### PR DESCRIPTION
- For weaviateSink and SupabaseSink we had the old optional properties (class and collection name) array while the pydantic object itself was not optional,  so, pydantic was failing - correctly - but our validation in the frontend was failing because class_name / collection_name was not being enforced as required