### PR TITLE
fix weaviate sink search

### DIFF
--- a/neumai/neumai/SinkConnectors/WeaviateSink.py
+++ b/neumai/neumai/SinkConnectors/WeaviateSink.py
@@ -222,7 +222,7 @@ class WeaviateSink(SinkConnector):
             )
 
             # Add .with_where(filter) only if filter is not empty
-            if filter:
+            if filters:
                 weaviate_filter = self.filter_conditions_to_weaviate_filter(filters)
                 client_query = client_query.with_where(weaviate_filter)
 


### PR DESCRIPTION
https://github.com/NeumTry/NeumAI/commit/576d3df9328fa015d6e1c6b8290fd73e86716a6d updated the parameter passed into `search` to `filters` but didn't update the conditional, causing errors.

Made this change locally in my venv and got search to work.