### PR TITLE
First version of smart search

### DIFF
--- a/neumai-tools/neumai_tools/PipelineCollection/PipelineCollection.py
+++ b/neumai-tools/neumai_tools/PipelineCollection/PipelineCollection.py
@@ -1,5 +1,6 @@
 from typing import List
-from scipy.spatial.distance import cosine
+from numpy import dot
+from numpy.linalg import norm
 from pydantic import BaseModel, Field
 from neumai.Pipelines.Pipeline import Pipeline
 from neumai.Shared.NeumSearch import NeumSearchResult
@@ -59,10 +60,9 @@ class PipelineCollection(BaseModel):
         for pipe in self.pipelines:
             pipe_representative = pipe.sink.get_representative_vector()
             query_vector = pipe.embed.embed_query(query=query)
-            distance_from_representative = cosine(pipe_representative, query_vector)
 
-            # Similarity score, hence subtracted distance from 1
-            pipe_to_similarity[pipe.id] = 1 - distance_from_representative
+            # calculating similarity score
+            pipe_to_similarity[pipe.id] = dot(pipe_representative, query_vector)/(norm(pipe_representative)*norm(query_vector))
 
         # We want to sort by decreasing oeder of similarity score
         # The more similar the query to a given representative vector
@@ -79,4 +79,3 @@ class PipelineCollection(BaseModel):
                     break
         search_results.append(results)
         return search_results
-        # raise NotImplementedError("In the works. Contact founders@tryneum.com for information")

--- a/neumai/neumai/SinkConnectors/LanceDBSink.py
+++ b/neumai/neumai/SinkConnectors/LanceDBSink.py
@@ -160,6 +160,12 @@ class LanceDBSink(SinkConnector):
             )
         return matches
     
+
+    def get_representative_vector(self) -> list:
+        db = self._get_db_connection()
+        tbl = db.open_table(self.table_name)
+        return list(tbl.to_pandas()['vector'].mean())
+    
     
     def info(self) -> NeumSinkInfo:
         try:

--- a/neumai/neumai/SinkConnectors/MarqoSink.py
+++ b/neumai/neumai/SinkConnectors/MarqoSink.py
@@ -185,7 +185,7 @@ class MarqoSink(SinkConnector):
             operator = condition.operator
 
             _filter_string+=self._get_marqo_filter(
-                column=field, value=condition.value, operator=operator)
+                column=field, value=condition.value, operator=operator.value)
                 
         if _filter_string.endswith(" AND "):
             _filter_string = _filter_string.rstrip(" AND ")


### PR DESCRIPTION
Adds an initial basic version of smart search.

**Description** - As per discussions in issue #43 , we need a method to route queries to appropriate/relevant collection from the `PipelineCollection` interface. Using collection representatives and their similarity with the query, we decide on which collection/pipe to search in.

**Approach** - For each pipe in the `PipelineCollection`, compute the representative vector of its respective sink. Then use the respective pipe's embed method to embed the query and compute its similarity with each pipe's representative. This gives a similarity score with respect to each pipe. Then search in descending order of similarity to get most relevant results.

**Note** - Currently supported on `Marqo`  and `LanceDB` sinks. Support for other sinks soon.

**Demo** - I have prepared a [notebook](https://drive.google.com/file/d/1e61SGT_-gCXEIQNShHZ3K_B9InZdPa6G/view?usp=sharing) which I have tested on my local system. I have created a custom embedding class in it to test quickly. Make sure to spin up your marqo instance before running the notebook.

Looking for review and feedback. 